### PR TITLE
Streamingapi

### DIFF
--- a/luno_python/stream_client.py
+++ b/luno_python/stream_client.py
@@ -187,6 +187,7 @@ async def stream_market(
             url,
             origin='http://localhost/',
             ping_interval=None,
+            max_size=2**21,
     ) as websocket:
 
         auth = json.dumps({

--- a/luno_python/stream_client.py
+++ b/luno_python/stream_client.py
@@ -80,8 +80,7 @@ class _MarketStreamState:
             return
 
         seq = update['sequence']
-        sequenceChange = int(seq) - int(self._sequence)
-        if sequenceChange != 1:
+        if int(seq) != int(self._sequence)+1:
             raise OutOfOrderMessageException()
 
         trades = update.get('trade_updates')

--- a/luno_python/stream_client.py
+++ b/luno_python/stream_client.py
@@ -80,7 +80,8 @@ class _MarketStreamState:
             return
 
         seq = update['sequence']
-        if seq <= self._sequence:
+        sequenceChange = int(seq) - int(self._sequence)
+        if sequenceChange != 1:
             raise OutOfOrderMessageException()
 
         trades = update.get('trade_updates')
@@ -148,10 +149,8 @@ async def _read_from_websocket(ws, pair: Pair, update_f: StateUpdate):
             update_f(pair, state.get_snapshot(), None)
             continue
 
-        try:
-            state.process_update(body)
-        except OutOfOrderMessageException:
-            continue
+        #could raise OutOfOrderMessageException
+        state.process_update(body)
 
         update_f(pair, state.get_snapshot(), body)
 


### PR DESCRIPTION
Recreating pull request:

Issues:

1.  Client only raises and OutOfMessageOrderException when the sequence number is <= the last seen sequence number. If a sequence number is skipped (client receives message n+2 instead of n+1) the client still operates as if synchronised with the server.

2. The current implementation raises an OutOfMessageOrderException which is caught but ignored - the luno website recommends restarting the client if this happens to reinitialise the state of the order book.

3. Since the orderbook size has increased (because bitcoin is the bomb-diggity 🚀 ), the websocket client is unable to initialise the state of the order book. Here is the error:

```
/lib/python3.7/site-packages/websockets/framing.py", line 127, in read
    f"payload length exceeds size limit ({length} > {max_size} bytes)"
websockets.exceptions.PayloadTooBig: payload length exceeds size limit (1068642 > 1048576 bytes)

    raise self.connection_closed_exc()
websockets.exceptions.ConnectionClosedError: code = 1006 (connection closed abnormally [internal]), no reason

```
The max_size of the payload can be adjusted on connection, increasing it to 2^21 solves the order book initialisation.
